### PR TITLE
Cleanup stores on destroy

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -46,13 +46,6 @@
 		loading = false;
 	}
 
-	onMount(() => {
-		$highlightedItemIndex = -1;
-		$selectedItemIndex = -1;
-		$selectedCells = [];
-		$highlightedCells = [];
-	});
-
 	let showFilters = false;
 
 	let activeLabels = $page.url.searchParams.getAll('label').map((l) => parseInt(l));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { highlights } from '$stores/sudokuStore';
 	import SudokuList from '$components/Sudoku/SudokuList.svelte';
 	import PuzzleLabel from '$ui/PuzzleLabel.svelte';
 	import Filters from '$icons/Filters.svelte';
@@ -12,8 +10,6 @@
 
 	export let data: PageData;
 	let sudokus = data.sudokuData;
-
-	const { selectedItemIndex, selectedCells, highlightedCells, highlightedItemIndex } = highlights;
 
 	let currentCursor: Date | null = null;
 	let nextCursor: Date | null = null;

--- a/src/routes/sudoku/[id]/+page.svelte
+++ b/src/routes/sudoku/[id]/+page.svelte
@@ -3,7 +3,7 @@
 	import SudokuGame from '$components/Sudoku/Game/SudokuGame.svelte';
 	import SudokuInfo from '$components/Sudoku/SudokuInfo.svelte';
 	import { editorHistory, gameHistory, highlights } from '$stores/sudokuStore';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { openModal } from '$stores/modalStore';
 	import FinishedSudokuModal from '$components/Modals/FinishedSudokuModal.svelte';
@@ -11,6 +11,7 @@
 	import type { PageData } from './$types';
 	import { walkthroughStore } from '$stores/walkthroughStore';
 	import { fillWalkthroughStore } from '$utils/fillWalkthroughStore';
+	import { resetAllSudokuStores } from '$utils/resetAllStores';
 
 	export let data: PageData;
 
@@ -53,6 +54,10 @@
 			now = Date.now();
 		}, 1000);
 		document.addEventListener('visibilitychange', handleVisibilityChange);
+	});
+
+	onDestroy(() => {
+		resetAllSudokuStores();
 	});
 
 	onMount(async () => {

--- a/src/routes/sudoku/editor/+page.svelte
+++ b/src/routes/sudoku/editor/+page.svelte
@@ -3,7 +3,7 @@
 	import SudokuEditor from '$components/Sudoku/Editor/SudokuEditor.svelte';
 	import Button from '$ui/Button.svelte';
 	import Input from '$ui/Input.svelte';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import {
 		defaultCentermarks,
@@ -25,6 +25,7 @@
 	import trpc, { type InferMutationInput } from '$lib/client/trpc';
 	import { fillWalkthroughStore } from '$utils/fillWalkthroughStore';
 	import RichTextEditor from '$components/RichTextEditor.svelte';
+	import { resetAllSudokuStores } from '$utils/resetAllStores';
 
 	export let data: PageData;
 
@@ -120,6 +121,10 @@
 		if ($page.url.searchParams.get('import')) {
 			openModal(ImportFromFPuzzles);
 		}
+	});
+
+	onDestroy(() => {
+		resetAllSudokuStores();
 	});
 
 	type Tabs = 'editor' | 'game' | 'form';

--- a/src/routes/sudoku/fpuzzle/+page.svelte
+++ b/src/routes/sudoku/fpuzzle/+page.svelte
@@ -6,8 +6,7 @@
 	import { decompressFromBase64 } from '$features/fpuzzles/compressor';
 	import { defaultValues } from '$utils/defaults';
 	import { importFPuzzleIntoEditorHistory } from '$features/fpuzzles/importFPuzzleIntoEditor';
-	import { onMount } from 'svelte';
-	import { onDestroy } from 'svelte/types/runtime/internal/lifecycle';
+	import { onDestroy, onMount } from 'svelte';
 	import { resetAllSudokuStores } from '$utils/resetAllStores';
 
 	// TIMER: one that does not run when the tab is inactive, but runs as if it had.

--- a/src/routes/sudoku/fpuzzle/+page.svelte
+++ b/src/routes/sudoku/fpuzzle/+page.svelte
@@ -7,6 +7,8 @@
 	import { defaultValues } from '$utils/defaults';
 	import { importFPuzzleIntoEditorHistory } from '$features/fpuzzles/importFPuzzleIntoEditor';
 	import { onMount } from 'svelte';
+	import { onDestroy } from 'svelte/types/runtime/internal/lifecycle';
+	import { resetAllSudokuStores } from '$utils/resetAllStores';
 
 	// TIMER: one that does not run when the tab is inactive, but runs as if it had.
 	let now = Date.now();
@@ -62,6 +64,10 @@
 		let dim = editorHistory.getClue('dimensions');
 		gameHistory.set({ values: defaultValues(dim) });
 		loading = false;
+	});
+
+	onDestroy(() => {
+		resetAllSudokuStores();
 	});
 
 	const sudokuClues = editorHistory.subscribeToClues();

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -36,13 +36,6 @@
 			}
 		});
 	}
-
-	onMount(() => {
-		$highlightedItemIndex = -1;
-		$selectedItemIndex = -1;
-		$selectedCells = [];
-		$highlightedCells = [];
-	});
 </script>
 
 <svelte:head>

--- a/src/routes/user/[id]/+page.svelte
+++ b/src/routes/user/[id]/+page.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
 	import { openModal } from '$stores/modalStore';
 	import DangerActionModal from '$components/Modals/DangerActionModal.svelte';
-	import { onMount } from 'svelte';
-	import { highlights } from '$stores/sudokuStore';
 	import SudokuList from '$components/Sudoku/SudokuList.svelte';
 	import trpc from '$lib/client/trpc';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
-
-	const { selectedItemIndex, selectedCells, highlightedCells, highlightedItemIndex } = highlights;
 
 	let nextCursor: Date | null = null;
 	$: nextCursor = data.sudokus.nextCursor;

--- a/src/utils/resetAllStores.ts
+++ b/src/utils/resetAllStores.ts
@@ -1,0 +1,14 @@
+import { editorHistory, gameHistory, highlights, inputMode } from '$stores/sudokuStore';
+
+export function resetAllSudokuStores(): void {
+	const { highlightedCells, highlightedItemIndex, selectedCells, selectedItemIndex, wrongCells } =
+		highlights;
+	inputMode.set('values');
+	highlightedItemIndex.set(-1);
+	selectedItemIndex.set(-1);
+	selectedCells.set([]);
+	highlightedCells.set([]);
+	wrongCells.set([]);
+	editorHistory.reset();
+	gameHistory.reset();
+}


### PR DESCRIPTION
## Description

In an attempt to solve #6 I found the solution to be cumbersome, and thought it way easier to just clear up the stores when the sudoku pages are destroyed. I think this should solve our problems with the stores polluting across pages, but I might be wrong.

If i put everything inside contexts, the stores would have to point around a lot of pointers to update functions, and even though it would be the "right" way, the developer experience was way worse.

I still think we can clean up some of the stores, and perhaps rely less heavily on them in the future

## Checklist

- [x] I have checked for other existing PR's which might implement the same features/fixes
- [x] I have marked & linked relevant issues
- [x] I have created new issues found/created in this PR and linked to this PR
- [x] I have added tests to relevant code, and added regression test if this is a bug fix

## This PR closes

<!--
  Automatically link an issue to this PR https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
  Use one of: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved
-->

- Closes #6, not by doing the proposed solution, though
