### PR TITLE
Fix walkthrough editor descriptions getting out of sync, and add shortcut

### DIFF
--- a/src/components/Modals/ControllerHelpModal.svelte
+++ b/src/components/Modals/ControllerHelpModal.svelte
@@ -136,6 +136,22 @@
 					</li>
 				</ul>
 			</section>
+
+			<section class="mb-2">
+				<h2 class="text-lg font-semibold">Walkthrough</h2>
+				<p>
+					The walkthrough is accessed by clicking the icon with the walking person below the
+					controller. When playing a game, you can follow along in the modal, or you can press the
+					button in the top right corner to open the walkthrough in a new tab. If you are creating
+					your own puzzle the same modal can be used to create a walkthrough.
+				</p>
+
+				<p>
+					If you don't want to open the modal everytime you want to add a step, you can use the "w"
+					shortcut, which will add the step for you. To add a description you still have to open the
+					modal, though.
+				</p>
+			</section>
 		{/if}
 
 		{#if mode === 'editor'}

--- a/src/components/Sudoku/Game/Controller/index.svelte
+++ b/src/components/Sudoku/Game/Controller/index.svelte
@@ -142,6 +142,10 @@
 				highlightedCells.set(scanner.getHighlightedCells(get(selectedCells)));
 				break;
 			}
+			case 'w': {
+				k.preventDefault();
+				walkthroughStore.addStep();
+			}
 		}
 	}
 

--- a/src/features/walkthroughs/WalkthroughEditor.svelte
+++ b/src/features/walkthroughs/WalkthroughEditor.svelte
@@ -27,7 +27,7 @@
 		{#if $walkthroughStore.length === 0}
 			<p class="text-gray-700">No steps added yet</p>
 		{/if}
-		{#each $walkthroughStore as { step, description }, i}
+		{#each $walkthroughStore as { step, description }, i (`${description}-step-${i}`)}
 			<div>
 				<div>
 					<div class="flex space-x-4 items-center mb-2 mt-2">
@@ -43,20 +43,23 @@
 							on:click={() => walkthroughStore.addStep(i)}
 							title="Insert a new step"
 							class="w-6 h-6 rounded-full p-1 hover:bg-red-100 hover:text-red-600"
-							><ArrowsOutLineVertical size={16} /></button
 						>
+							<ArrowsOutLineVertical size={16} />
+						</button>
 						<button
 							on:click={() => walkthroughStore.addStep(i, true)}
 							title="Replace this step"
 							class="w-6 h-6 rounded-full p-1 hover:bg-red-100 hover:text-red-600"
-							><Swap size={16} /></button
 						>
+							<Swap size={16} />
+						</button>
 						<button
 							on:click={() => walkthroughStore.removeStep(i)}
 							title="Delete this step"
 							class="w-6 h-6 rounded-full p-1 hover:bg-red-100 hover:text-red-600"
-							><Trash size={16} /></button
 						>
+							<Trash size={16} />
+						</button>
 					</div>
 				</div>
 				<div class="grid gap-2 grid-cols-2">


### PR DESCRIPTION
## Description

This fixes the bug where editor descriptions got out of sync when deleting and creating new steps. It was really just an index on the each block that was missing. This also adds the "w" shortcut to add a step to the walkthrough, and also adds a description of the shortcut to the faq modal

## Checklist

- [x] I have checked for other existing PR's which might implement the same features/fixes
- [x] I have marked & linked relevant issues
- [x] I have created new issues found/created in this PR and linked to this PR
- [x] I have added tests to relevant code, and added regression test if this is a bug fix
