### PR TITLE
Load walkthrough at mount

### DIFF
--- a/apps/website/src/routes/sudoku/[id]/+page.svelte
+++ b/apps/website/src/routes/sudoku/[id]/+page.svelte
@@ -9,8 +9,6 @@
   import { fillCluesWithDefaults } from '$utils/fillSudokuWithDefaults';
   import { defaultGameData } from '@octopuzzles/sudoku-utils';
   import ExportButton from '$components/ExportButton.svelte';
-  import { trpc } from '$lib/trpc/client';
-  import { page } from '$app/stores';
   import type { WalkthroughStep } from '@octopuzzles/models';
 
   export let data: PageData;
@@ -21,6 +19,14 @@
   const clues = fillCluesWithDefaults(data.sudoku);
   let gameData = data.gameData ?? defaultGameData(data.sudoku.dimensions);
   const scannerSettings = me.settings;
+
+  onMount(() => {
+    data.streamed.walkthrough.then((w) => {
+      if (w != null) {
+        walkthrough = w.steps;
+      }
+    });
+  });
 
   // TIMER: one that does not run when the tab is inactive, but runs as if it had.
   let now = Date.now();
@@ -49,17 +55,6 @@
       now = Date.now();
     }, 1000);
     document.addEventListener('visibilitychange', handleVisibilityChange);
-  });
-
-  const getWalkthrough = async (): Promise<void> => {
-    const res = await trpc($page).walkthroughs.get.query({ sudokuId: data.sudoku.id });
-    if (res != null) {
-      walkthrough = res.steps;
-    }
-  };
-
-  onMount(() => {
-    void getWalkthrough();
   });
 
   function takeScreenshot(): void {
@@ -108,7 +103,7 @@
     showFinishedSudokuModal = true;
   }}
   solution={data.sudoku.solution ?? undefined}
-  walkthrough={walkthrough ?? []}
+  {walkthrough}
   {clues}
   bind:gameData
 >

--- a/apps/website/src/routes/sudoku/[id]/+page.ts
+++ b/apps/website/src/routes/sudoku/[id]/+page.ts
@@ -8,16 +8,12 @@ export const load: PageLoad = async (event) => {
   const trpcClient = trpc(event);
   const sudokuId = parseInt(event.params.id);
   const dataParam = event.url.searchParams.get('data');
-  const [sudoku, walkthrough] = await Promise.all([
-    trpcClient.sudokus.get.query({ id: sudokuId }),
-    trpcClient.walkthroughs.get.query({ sudokuId })
-  ]);
+  const sudoku = await trpcClient.sudokus.get.query({ id: sudokuId });
   if (sudoku == null) {
     throw error(404, 'Not found');
   }
   return {
     sudoku,
-    walkthrough,
     gameData:
       dataParam != null
         ? (decompressFromBase64(dataParam.replace(/ /g, '+')) as GameData)

--- a/apps/website/src/routes/sudoku/[id]/+page.ts
+++ b/apps/website/src/routes/sudoku/[id]/+page.ts
@@ -14,6 +14,7 @@ export const load: PageLoad = async (event) => {
   }
   return {
     sudoku,
+    streamed: { walkthrough: trpcClient.walkthroughs.get.query({ sudokuId }) },
     gameData:
       dataParam != null
         ? (decompressFromBase64(dataParam.replace(/ /g, '+')) as GameData)


### PR DESCRIPTION
## Description

<!-- WRITE SOMETHING HERE -->
Load walkthrough on mount rather than on page navigation. It can take quite some time to load a sudoku page because the walkthrough has to be loaded before the page can be shown, but that is bad, because the walkthrough is not needed instantly

## Checklist

- [x] I have checked for other existing PR's which might implement the same features/fixes
- [x] I have marked & linked relevant issues
- [x] I have created new issues found/created in this PR and linked to this PR
- [x] I have added tests to relevant code, and added regression test if this is a bug fix

## This PR closes

<!--
  Automatically link an issue to this PR https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
  Use one of: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved
-->

- Closes #172 
